### PR TITLE
Use resin-token to retrieve the authentication token

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ The relative url to make the request to.
 
 The absolute url of the resin server to make the request to.
 
-#### String options.token
-
-The session token to use.
-
 #### String options.method
 
 The HTTP method to perform. Defaults to `GET`.

--- a/build/utils.js
+++ b/build/utils.js
@@ -1,8 +1,10 @@
-var ProgressState, connection, errors, progress;
+var ProgressState, connection, errors, progress, token;
 
 progress = require('request-progress');
 
 errors = require('resin-errors');
+
+token = require('resin-token');
 
 connection = require('./connection');
 
@@ -32,11 +34,13 @@ exports.addAuthorizationHeader = function(headers, token) {
 };
 
 exports.authenticate = function(options, callback) {
+  var sessionToken;
   if (options == null) {
     throw new errors.ResinMissingParameter('options');
   }
-  if (options.token != null) {
-    options.headers = exports.addAuthorizationHeader(options.headers, options.token);
+  sessionToken = token.get();
+  if (sessionToken != null) {
+    options.headers = exports.addAuthorizationHeader(options.headers, sessionToken);
   }
   return callback();
 };

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,5 +1,6 @@
 progress = require('request-progress')
 errors = require('resin-errors')
+token = require('resin-token')
 connection = require('./connection')
 ProgressState = require('./progress-state')
 
@@ -21,8 +22,10 @@ exports.authenticate = (options, callback) ->
 	if not options?
 		throw new errors.ResinMissingParameter('options')
 
-	if options.token?
-		options.headers = exports.addAuthorizationHeader(options.headers, options.token)
+	sessionToken = token.get()
+
+	if sessionToken?
+		options.headers = exports.addAuthorizationHeader(options.headers, sessionToken)
 
 	return callback()
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "lodash": "^3.5.0",
     "request": "^2.53.0",
     "request-progress": "^0.3.1",
-    "resin-errors": "^1.0.0"
+    "resin-errors": "^1.0.0",
+    "resin-token": "^1.0.0"
   }
 }

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -1,6 +1,7 @@
 _ = require('lodash')
 expect = require('chai').expect
 fs = require('fs')
+token = require('resin-token')
 nock = require('nock')
 url = require('url')
 sinon = require('sinon')
@@ -172,7 +173,7 @@ describe 'Request:', ->
 	describe 'given there is a token', ->
 
 		beforeEach ->
-			@token = 1234
+			token.set('1234')
 
 		describe '#request()', ->
 
@@ -182,7 +183,6 @@ describe 'Request:', ->
 					method: 'GET'
 					url: @uris.ok
 					remoteUrl: REMOTE_URL
-					token: @token
 				}, (error, response) ->
 					authorizationHeader = response?.request.headers.Authorization
 
@@ -192,6 +192,9 @@ describe 'Request:', ->
 					done()
 
 	describe 'given there is not a token', ->
+
+		beforeEach ->
+			token.remove()
 
 		describe '#request()', ->
 

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -1,6 +1,7 @@
 _ = require('lodash')
 expect = require('chai').expect
 sinon = require('sinon')
+token = require('resin-token')
 utils = require('../lib/utils')
 connection = require('../lib/connection')
 
@@ -102,10 +103,11 @@ describe 'utils:', ->
 
 		describe 'given there is a token', ->
 
-			it 'should add the Authorization header', (done) ->
-				options =
-					token: 1234
+			beforeEach ->
+				token.set('1234')
 
+			it 'should add the Authorization header', (done) ->
+				options = {}
 				utils.authenticate options, (error) ->
 					expect(error).to.not.exist
 					expect(options.headers.Authorization).to.equal('Bearer 1234')
@@ -113,9 +115,11 @@ describe 'utils:', ->
 
 		describe 'given there is no saved token', ->
 
+			beforeEach ->
+				token.remove()
+
 			it 'should not add the Authorization header', (done) ->
 				options = {}
-				expect(options).to.deep.equal({})
 
 				utils.authenticate options, (error) ->
 					expect(error).to.not.exist


### PR DESCRIPTION
Means passing the token option to request() is now unnecessary.