### PR TITLE
Manually pipe data from the download to options.pipe

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -54,7 +54,10 @@ exports.pipeRequest = function(options, callback, onProgress) {
   if (options.pipe == null) {
     throw new errors.ResinMissingOption('pipe');
   }
-  return progress(connection.request(options)).on('progress', ProgressState.createFromNodeRequestProgress(onProgress)).on('error', callback).pipe(options.pipe).on('error', callback).on('close', callback);
+  options.pipe.on('error', callback).on('close', callback);
+  return progress(connection.request(options)).on('progress', ProgressState.createFromNodeRequestProgress(onProgress)).on('error', callback).on('end', callback).on('data', function(chunk) {
+    return options.pipe.write(chunk);
+  });
 };
 
 exports.sendRequest = function(options, callback) {

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -39,12 +39,21 @@ exports.pipeRequest = (options, callback, onProgress) ->
 		throw new errors.ResinMissingOption('pipe')
 
 	# TODO: Find a way to test this
+
+	options.pipe
+		.on('error', callback)
+		.on('close', callback)
+
 	progress(connection.request(options))
 		.on('progress', ProgressState.createFromNodeRequestProgress(onProgress))
 		.on('error', callback)
-		.pipe(options.pipe)
-		.on('error', callback)
-		.on('close', callback)
+		.on('end', callback)
+
+		# For some reason, piping the stream to options.pipe
+		# make the process exit suddenly after ~10s.
+		# This is most likely an issue with node-request.
+		.on 'data', (chunk) ->
+			options.pipe.write(chunk)
 
 exports.sendRequest = (options, callback) ->
 	connection.request options, (error, response) ->

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "request-progress": "^0.3.1",
     "resin-errors": "^1.0.0",
     "resin-settings-client": "^1.0.0",
-    "resin-token": "^1.0.0"
+    "resin-token": "^1.2.0"
   }
 }


### PR DESCRIPTION
Piping directly makes the process exit after ~10s.