### PR TITLE
Read onProgress function from the options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ npm install --save resin-request
 Documentation
 -------------
 
-### resinRequest.request(Object options, Function callback[, Function onProgress])
+### resinRequest.request(Object options, Function callback)
 
 Make an HTTP request to a resin server.
 
@@ -36,17 +36,7 @@ The HTTP method to perform. Defaults to `GET`.
 
 Optional request JSON body.
 
-#### StreamWritable options.pipe
-
-A stream to pipe the request. Useful if downloading a file.
-
-If you use this option, you may use the `onProgress` callback.
-
-#### Function callback(error, response, body)
-
-This function is called when the request is completed.
-
-#### Function onProgress(state)
+#### Function options.onProgress (state)
 
 A function called to notify the progress if piping the request.
 
@@ -59,6 +49,16 @@ The `state` object contains:
 - `delta`: The number of bytes received since the last call to `onProgress`.
 
 Notice that if the resource doesn't expose a `content-length` containing the size of the resource, `state` will be undefined.
+
+#### StreamWritable options.pipe
+
+A stream to pipe the request. Useful if downloading a file.
+
+If you use this option, you may use the `onProgress` callback.
+
+#### Function callback(error, response, body)
+
+This function is called when the request is completed.
 
 Debug
 -----

--- a/build/request.js
+++ b/build/request.js
@@ -12,12 +12,9 @@ utils = require('./utils');
 
 urlResolve = require('url').resolve;
 
-exports.request = function(options, callback, onProgress) {
+exports.request = function(options, callback) {
   if (options == null) {
     options = {};
-  }
-  if (onProgress == null) {
-    onProgress = _.noop;
   }
   if (options.url == null) {
     throw new errors.ResinMissingOption('url');
@@ -28,7 +25,8 @@ exports.request = function(options, callback, onProgress) {
   }
   _.defaults(options, {
     method: 'GET',
-    gzip: true
+    gzip: true,
+    onProgress: _.noop
   });
   return async.waterfall([
     function(callback) {
@@ -37,7 +35,7 @@ exports.request = function(options, callback, onProgress) {
       return utils.authenticate(options, callback);
     }, function(callback) {
       if (options.pipe != null) {
-        return utils.pipeRequest(options, callback, onProgress);
+        return utils.pipeRequest(options, callback);
       } else {
         return utils.sendRequest(options, callback);
       }

--- a/build/utils.js
+++ b/build/utils.js
@@ -47,7 +47,7 @@ exports.authenticate = function(options, callback) {
   return callback();
 };
 
-exports.pipeRequest = function(options, callback, onProgress) {
+exports.pipeRequest = function(options, callback) {
   if (options == null) {
     throw new errors.ResinMissingParameter('options');
   }
@@ -55,7 +55,7 @@ exports.pipeRequest = function(options, callback, onProgress) {
     throw new errors.ResinMissingOption('pipe');
   }
   options.pipe.on('error', callback).on('close', callback);
-  return progress(connection.request(options)).on('progress', ProgressState.createFromNodeRequestProgress(onProgress)).on('error', callback).on('end', callback).on('data', function(chunk) {
+  return progress(connection.request(options)).on('progress', ProgressState.createFromNodeRequestProgress(options.onProgress)).on('error', callback).on('end', callback).on('data', function(chunk) {
     return options.pipe.write(chunk);
   });
 };

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -6,7 +6,7 @@ utils = require('./utils')
 
 urlResolve = require('url').resolve
 
-exports.request = (options = {}, callback, onProgress = _.noop) ->
+exports.request = (options = {}, callback) ->
 
 	if not options.url?
 		throw new errors.ResinMissingOption('url')
@@ -17,6 +17,7 @@ exports.request = (options = {}, callback, onProgress = _.noop) ->
 	_.defaults options,
 		method: 'GET'
 		gzip: true
+		onProgress: _.noop
 
 	async.waterfall([
 
@@ -28,7 +29,7 @@ exports.request = (options = {}, callback, onProgress = _.noop) ->
 
 		(callback) ->
 			if options.pipe?
-				utils.pipeRequest(options, callback, onProgress)
+				utils.pipeRequest(options, callback)
 			else
 				utils.sendRequest(options, callback)
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -30,7 +30,7 @@ exports.authenticate = (options, callback) ->
 
 	return callback()
 
-exports.pipeRequest = (options, callback, onProgress) ->
+exports.pipeRequest = (options, callback) ->
 
 	if not options?
 		throw new errors.ResinMissingParameter('options')
@@ -45,7 +45,7 @@ exports.pipeRequest = (options, callback, onProgress) ->
 		.on('close', callback)
 
 	progress(connection.request(options))
-		.on('progress', ProgressState.createFromNodeRequestProgress(onProgress))
+		.on('progress', ProgressState.createFromNodeRequestProgress(options.onProgress))
 		.on('error', callback)
 		.on('end', callback)
 

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -151,6 +151,7 @@ describe 'Request:', ->
 				method: 'GET'
 				url: @uris.nojson
 				pipe: fs.createWriteStream(outputFile)
+				onProgress: _.noop
 			}, (error) =>
 				expect(error).to.not.exist
 				fs.readFile outputFile, { encoding: 'utf8' }, (error, contents) =>
@@ -158,7 +159,6 @@ describe 'Request:', ->
 					expect(contents).to.equal(@responses.nojson)
 					mockFs.restore()
 					done()
-			, _.noop
 
 	describe 'given there is a token', ->
 

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -132,14 +132,14 @@ describe 'utils:', ->
 
 			it 'should throw an error', ->
 				expect ->
-					utils.pipeRequest(null, _.noop, _.noop)
+					utils.pipeRequest(null, _.noop)
 				.to.throw('Missing parameter: options')
 
 		describe 'if no pipe option', ->
 
 			it 'should throw an error', ->
 				expect ->
-					utils.pipeRequest({}, _.noop, _.noop)
+					utils.pipeRequest({}, _.noop)
 				.to.throw('Missing option: pipe')
 
 	describe '.sendRequest()', ->


### PR DESCRIPTION
Accepting onProgress as the last argument breaks the NodeJS convention
where the last argument is supposed to be the callback.