### PR TITLE
Use Content-Length value as stream.length

### DIFF
--- a/build/request.js
+++ b/build/request.js
@@ -183,6 +183,7 @@ exports.stream = function(options) {
       });
       return pass.on('response', function(response) {
         if (!utils.isErrorCode(response.statusCode)) {
+          pass.length = _.parseInt(response.headers['content-length']) || void 0;
           return resolve(pass);
         }
         return utils.getStreamData(pass).then(function(data) {

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -157,6 +157,7 @@ exports.stream = (options = {}) ->
 
 			pass.on 'response', (response) ->
 				if not utils.isErrorCode(response.statusCode)
+					pass.length = _.parseInt(response.headers['content-length']) or undefined
 					return resolve(pass)
 
 				# If status code is an error code, interpret

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -364,6 +364,40 @@ describe 'Request:', ->
 							m.chai.expect(data).to.equal('GET')
 						.nodeify(done)
 
+			describe 'given an endpoint with a content-length header', ->
+
+				beforeEach ->
+					message = 'Lorem ipsum dolor sit amet'
+					nock(settings.get('remoteUrl'))
+						.get('/foo').reply(200, message, 'Content-Length': String(message.length))
+
+				afterEach ->
+					nock.cleanAll()
+
+				it 'should become a stream with a length property', (done) ->
+					request.stream
+						url: '/foo'
+					.then (stream) ->
+						m.chai.expect(stream.length).to.equal(26)
+					.nodeify(done)
+
+			describe 'given an endpoint with an invalid content-length header', ->
+
+				beforeEach ->
+					message = 'Lorem ipsum dolor sit amet'
+					nock(settings.get('remoteUrl'))
+						.get('/foo').reply(200, message, 'Content-Length': 'Hello')
+
+				afterEach ->
+					nock.cleanAll()
+
+				it 'should become a stream with an undefined length property', (done) ->
+					request.stream
+						url: '/foo'
+					.then (stream) ->
+						m.chai.expect(stream.length).to.be.undefined
+					.nodeify(done)
+
 	describe 'given the token needs to be updated', ->
 
 		beforeEach (done) ->


### PR DESCRIPTION
When streaming an HTTP request, if the response contains a
`Content-Length` header, parse it and use it as the `length` property.

This `length` property is used by Resin Image Write to emit correct
progress information when piping a download directly to a drive.