### PR TITLE
Implement custom .mime property based on Content-Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This function emits a `progress` event, passing an object with the following pro
 The stream may also contain the following custom properties:
 
 - `Number .length`: Calculated from the `Content-Length` HTTP header.
+- `String .mime`: Equals the value of the `Content-Type` HTTP header.
 
 **Kind**: static method of <code>[request](#module_request)</code>  
 **Summary**: Stream an HTTP response from Resin.io.  

--- a/build/request.js
+++ b/build/request.js
@@ -149,6 +149,7 @@ exports.send = function(options) {
  * The stream may also contain the following custom properties:
  *
  * - `Number .length`: Calculated from the `Content-Length` HTTP header.
+ * - `String .mime`: Equals the value of the `Content-Type` HTTP header.
  *
  * @param {Object} options - options
  * @param {String} [options.method='GET'] - method
@@ -188,6 +189,7 @@ exports.stream = function(options) {
       return pass.on('response', function(response) {
         if (!utils.isErrorCode(response.statusCode)) {
           pass.length = _.parseInt(response.headers['content-length']) || void 0;
+          pass.mime = response.headers['content-type'];
           return resolve(pass);
         }
         return utils.getStreamData(pass).then(function(data) {

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -123,6 +123,7 @@ exports.send = (options = {}) ->
 # The stream may also contain the following custom properties:
 #
 # - `Number .length`: Calculated from the `Content-Length` HTTP header.
+# - `String .mime`: Equals the value of the `Content-Type` HTTP header.
 #
 # @param {Object} options - options
 # @param {String} [options.method='GET'] - method
@@ -162,6 +163,7 @@ exports.stream = (options = {}) ->
 			pass.on 'response', (response) ->
 				if not utils.isErrorCode(response.statusCode)
 					pass.length = _.parseInt(response.headers['content-length']) or undefined
+					pass.mime = response.headers['content-type']
 					return resolve(pass)
 
 				# If status code is an error code, interpret

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -398,6 +398,23 @@ describe 'Request:', ->
 						m.chai.expect(stream.length).to.be.undefined
 					.nodeify(done)
 
+			describe 'given an endpoint with a content-type header', ->
+
+				beforeEach ->
+					message = 'Lorem ipsum dolor sit amet'
+					nock(settings.get('remoteUrl'))
+						.get('/foo').reply(200, message, 'Content-Type': 'application/octet-stream')
+
+				afterEach ->
+					nock.cleanAll()
+
+				it 'should become a stream with a mime property', (done) ->
+					request.stream
+						url: '/foo'
+					.then (stream) ->
+						m.chai.expect(stream.mime).to.equal('application/octet-stream')
+					.nodeify(done)
+
 	describe 'given the token needs to be updated', ->
 
 		beforeEach (done) ->


### PR DESCRIPTION
The addition of this property is helpful for later deciding whether to
uncompress the stream or not, without having to detect the mime type
manually.