### PR TITLE
Translate percent to percentage in progress event

### DIFF
--- a/build/estimate.js
+++ b/build/estimate.js
@@ -38,6 +38,10 @@ exports.getEstimator = function() {
     timeDelta = newTime - time;
     time = newTime;
     state.eta = Math.floor(remainingTicks * timeDelta) || void 0;
+    if (state.percent != null) {
+      state.percentage = state.percent;
+      delete state.percent;
+    }
     return state;
   };
 };

--- a/lib/estimate.coffee
+++ b/lib/estimate.coffee
@@ -40,4 +40,8 @@ exports.getEstimator = ->
 
 		state.eta = Math.floor(remainingTicks * timeDelta) or undefined
 
+		if state.percent?
+			state.percentage = state.percent
+			delete state.percent
+
 		return state

--- a/tests/estimate.spec.coffee
+++ b/tests/estimate.spec.coffee
@@ -4,6 +4,25 @@ estimate = require('../lib/estimate')
 
 describe 'Estimate:', ->
 
+	it 'should keep a percentage property', ->
+		estimator = estimate.getEstimator()
+		state = estimator
+			total: 1000
+			received: 500
+			percentage: 50
+
+		m.chai.expect(state.percentage).to.equal(50)
+
+	it 'should translate percent to percentage', ->
+		estimator = estimate.getEstimator()
+		state = estimator
+			total: 1000
+			received: 500
+			percent: 50
+
+		m.chai.expect(state.percentage).to.equal(50)
+		m.chai.expect(state.percent).to.not.exist
+
 	describe 'given updates various updates', ->
 
 		beforeEach ->


### PR DESCRIPTION
Currently, `request-progress` emits a progress event containing a
`percent` property, however Resin CLI Visuals and Resin Image Write call
this property `percentage`.

For consistency reason, we convert `percent` to `percentage` here.