### PR TITLE
Accept apikey as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Documentation
 <a name="module_request.send"></a>
 ### request.send(options) ⇒ <code>Promise.&lt;Object&gt;</code>
 This function automatically handles authorization with Resin.io.
-If you don't have an API key environment variable, the request is made anonymously.
+If you don't pass an API key, the request is made anonymously.
 This function automatically prepends the Resin.io host, therefore you should pass relative urls.
 
 **Kind**: static method of <code>[request](#module_request)</code>  
@@ -50,6 +50,7 @@ This function automatically prepends the Resin.io host, therefore you should pas
 | options | <code>Object</code> |  | options |
 | [options.method] | <code>String</code> | <code>&#x27;GET&#x27;</code> | method |
 | options.url | <code>String</code> |  | relative url |
+| [options.apikey] | <code>String</code> |  | API key |
 | [options.body] | <code>\*</code> |  | body |
 
 **Example**  

--- a/build/request.js
+++ b/build/request.js
@@ -60,7 +60,7 @@ prepareOptions = function(options) {
     json: true,
     baseUrl: settings.get('apiUrl'),
     qs: {
-      apikey: process.env[settings.get('apiKeyVariable')]
+      apikey: options.apikey
     }
   });
   if (url.parse(options.url).hostname != null) {
@@ -77,12 +77,13 @@ prepareOptions = function(options) {
  *
  * @description
  * This function automatically handles authorization with Resin.io.
- * If you don't have an API key environment variable, the request is made anonymously.
+ * If you don't pass an API key, the request is made anonymously.
  * This function automatically prepends the Resin.io host, therefore you should pass relative urls.
  *
  * @param {Object} options - options
  * @param {String} [options.method='GET'] - method
  * @param {String} options.url - relative url
+ * @param {String} [options.apikey] - API key
  * @param {*} [options.body] - body
  *
  * @returns {Promise<Object>} response

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -47,7 +47,7 @@ prepareOptions = (options = {}) ->
 		json: true
 		baseUrl: settings.get('apiUrl')
 		qs:
-			apikey: process.env[settings.get('apiKeyVariable')]
+			apikey: options.apikey
 
 	if url.parse(options.url).hostname?
 		delete options.baseUrl
@@ -61,12 +61,13 @@ prepareOptions = (options = {}) ->
 #
 # @description
 # This function automatically handles authorization with Resin.io.
-# If you don't have an API key environment variable, the request is made anonymously.
+# If you don't pass an API key, the request is made anonymously.
 # This function automatically prepends the Resin.io host, therefore you should pass relative urls.
 #
 # @param {Object} options - options
 # @param {String} [options.method='GET'] - method
 # @param {String} options.url - relative url
+# @param {String} [options.apikey] - API key
 # @param {*} [options.body] - body
 #
 # @returns {Promise<Object>} response

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -41,16 +41,11 @@ describe 'Request:', ->
 
 			describe 'given there is an api key', ->
 
-				beforeEach ->
-					process.env[settings.get('apiKeyVariable')] = 'asdf'
-
-				afterEach ->
-					delete process.env[settings.get('apiKeyVariable')]
-
 				it 'should not send an Authorization header', ->
 					promise = request.send
 						method: 'GET'
 						url: '/foo'
+						apikey: 'asdf'
 					.get('request')
 					.get('headers')
 					.get('Authorization')
@@ -60,6 +55,7 @@ describe 'Request:', ->
 					promise = request.send
 						method: 'GET'
 						url: '/foo'
+						apikey: 'asdf'
 					.get('request')
 					.get('uri')
 					.get('query')
@@ -324,16 +320,11 @@ describe 'Request:', ->
 
 			describe 'given there is an api key', ->
 
-				beforeEach ->
-					process.env[settings.get('apiKeyVariable')] = 'asdf'
-
-				afterEach ->
-					delete process.env[settings.get('apiKeyVariable')]
-
 				it 'should not send an Authorization header', (done) ->
 					request.stream
 						method: 'GET'
 						url: '/foo'
+						apikey: 'asdf'
 					.then (stream) ->
 						m.chai.expect(stream.response.request.headers.Authorization).to.be.undefined
 						utils.getStreamData(stream).return(undefined).nodeify(done)
@@ -342,14 +333,12 @@ describe 'Request:', ->
 					request.stream
 						method: 'GET'
 						url: '/foo'
+						apikey: 'asdf'
 					.then (stream) ->
 						m.chai.expect(stream.response.request.uri.query).to.equal('apikey=asdf')
 						utils.getStreamData(stream).return(undefined).nodeify(done)
 
 			describe 'given there is no api key', ->
-
-				beforeEach ->
-					delete process.env[settings.get('apiKeyVariable')]
 
 				it 'should not send an apikey query string', (done) ->
 					request.stream


### PR DESCRIPTION
Decouple Resin Request from the environment by requiring the api key to
be passed as an option instead of reading as an environment variable
directly.