### PR TITLE
Merge apikey with custom query strings

### DIFF
--- a/build/request.js
+++ b/build/request.js
@@ -54,7 +54,7 @@ prepareOptions = function(options) {
   if (options == null) {
     options = {};
   }
-  _.defaults(options, {
+  _.defaultsDeep(options, {
     method: 'GET',
     gzip: true,
     json: true,

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -41,7 +41,7 @@ estimate = require('./estimate')
 
 prepareOptions = (options = {}) ->
 
-	_.defaults options,
+	_.defaultsDeep options,
 		method: 'GET'
 		gzip: true
 		json: true

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -61,6 +61,18 @@ describe 'Request:', ->
 					.get('query')
 					m.chai.expect(promise).to.eventually.equal('apikey=asdf')
 
+				it 'should allow to set custom query string while preserving the api key', ->
+					promise = request.send
+						method: 'GET'
+						url: '/foo'
+						apikey: 'asdf'
+						qs:
+							foo: 'bar'
+					.get('request')
+					.get('uri')
+					.get('query')
+					m.chai.expect(promise).to.eventually.equal('foo=bar&apikey=asdf')
+
 			describe 'given there is no api key', ->
 
 				beforeEach ->
@@ -336,6 +348,17 @@ describe 'Request:', ->
 						apikey: 'asdf'
 					.then (stream) ->
 						m.chai.expect(stream.response.request.uri.query).to.equal('apikey=asdf')
+						utils.getStreamData(stream).return(undefined).nodeify(done)
+
+				it 'should allow to set custom query string while preserving the api key', (done) ->
+					request.stream
+						method: 'GET'
+						url: '/foo'
+						apikey: 'asdf'
+						qs:
+							foo: 'bar'
+					.then (stream) ->
+						m.chai.expect(stream.response.request.uri.query).to.equal('foo=bar&apikey=asdf')
 						utils.getStreamData(stream).return(undefined).nodeify(done)
 
 			describe 'given there is no api key', ->


### PR DESCRIPTION
Currently, if the user passed custom query strings, those would override
the apikey query. They should be merged together instead.