### PR TITLE
Pipe uncompressed data if no X-Transfer-Length

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -161,7 +161,7 @@ exports.requestProgress = function(options) {
     response.length = headers['content-length'] || headers['x-transfer-length'];
     return response.length = _.parseInt(response.length) || void 0;
   }).then(function(response) {
-    var pass, progressStream;
+    var pass, progressStream, responseData;
     progressStream = progress({
       time: 500,
       length: response.length
@@ -178,7 +178,12 @@ exports.requestProgress = function(options) {
         percentage: state.percentage
       });
     });
-    response.pipe(progressStream).pipe(pass);
+    if (response.headers['x-transfer-length'] != null) {
+      responseData = response;
+    } else {
+      responseData = requestStream;
+    }
+    responseData.pipe(progressStream).pipe(pass);
     pass.response = response;
     return pass;
   });

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -151,7 +151,14 @@ exports.requestProgress = (options) ->
 				received: state.transferred
 				eta: state.eta
 				percentage: state.percentage
-		response.pipe(progressStream).pipe(pass)
+
+		if response.headers['x-transfer-length']?
+			responseData = response
+		else
+			responseData = requestStream
+
+		responseData.pipe(progressStream).pipe(pass)
+
 		pass.response = response
 
 		return pass


### PR DESCRIPTION
The `X-Transfer-Length` stands for *compressed* transfer length while
`Content-Length` represents the *uncompressed* counterpart.

This means we have to pipe compressed or uncompressed data to the client
accordingly.

Fixes: https://github.com/resin-io/resin-cli/issues/267