### PR TITLE
Fix X-Transfer-Length decompression bug

### DIFF
--- a/build/progress.js
+++ b/build/progress.js
@@ -1,0 +1,117 @@
+
+/*
+Copyright 2016 Resin.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+var getProgressStream, progress, request, rindle, stream, utils, zlib, _;
+
+_ = require('lodash');
+
+zlib = require('zlib');
+
+request = require('request');
+
+stream = require('stream');
+
+progress = require('progress-stream');
+
+rindle = require('rindle');
+
+utils = require('./utils');
+
+
+/**
+ * @summary Get progress stream
+ * @function
+ * @private
+ *
+ * @param {Object} response - request response object
+ * @param {Number} total - response total
+ * @param {Function} [onState] - on state callback (state)
+ * @returns {Stream} progress stream
+ *
+ * @example
+ * progressStream = getProgressStream response, (state) ->
+ * 	console.log(state)
+ *
+ * return requestStream.pipe(progressStream).pipe(output)
+ */
+
+getProgressStream = function(response, total, onState) {
+  var progressStream;
+  if (onState == null) {
+    onState = _.noop;
+  }
+  progressStream = progress({
+    time: 500,
+    length: total
+  });
+  progressStream.on('progress', function(state) {
+    if (state.length === 0) {
+      return onState(void 0);
+    }
+    return onState({
+      total: state.length,
+      received: state.transferred,
+      eta: state.eta,
+      percentage: state.percentage
+    });
+  });
+  return progressStream;
+};
+
+
+/**
+ * @summary Make a node request with progress
+ * @function
+ * @protected
+ *
+ * @param {Object} options - request options
+ * @returns {Promise<Stream>} request stream
+ *
+ * @example
+ * progress.estimate(options).then (stream) ->
+ *		stream.pipe(fs.createWriteStream('foo/bar'))
+ *		stream.on 'progress', (state) ->
+ *			console.log(state)
+ */
+
+exports.estimate = function(options) {
+  var passStream, requestStream;
+  requestStream = request(options);
+  passStream = new stream.PassThrough();
+  requestStream.pipe(passStream);
+  return rindle.onEvent(requestStream, 'response').then(function(response) {
+    var gunzip, output, progressStream, responseLength, total;
+    responseLength = utils.getResponseLength(response);
+    output = new stream.PassThrough();
+    output.response = response;
+    output.response.length = responseLength.uncompressed;
+    total = responseLength.uncompressed || responseLength.compressed;
+    progressStream = getProgressStream(response, total, function(state) {
+      return output.emit('progress', state);
+    });
+    if (utils.isResponseCompressed(response)) {
+      gunzip = new zlib.createGunzip();
+      if ((responseLength.compressed != null) && (responseLength.uncompressed == null)) {
+        passStream.pipe(progressStream).pipe(gunzip).pipe(output);
+      } else {
+        passStream.pipe(gunzip).pipe(progressStream).pipe(output);
+      }
+    } else {
+      passStream.pipe(progressStream).pipe(output);
+    }
+    return output;
+  });
+};

--- a/build/request.js
+++ b/build/request.js
@@ -18,7 +18,7 @@ limitations under the License.
 /**
  * @module request
  */
-var Promise, errors, prepareOptions, request, requestAsync, rindle, settings, token, url, utils, _;
+var Promise, errors, prepareOptions, progress, request, requestAsync, rindle, settings, token, url, utils, _;
 
 Promise = require('bluebird');
 
@@ -40,17 +40,19 @@ token = require('resin-token');
 
 utils = require('./utils');
 
+progress = require('./progress');
+
 prepareOptions = function(options) {
   if (options == null) {
     options = {};
   }
   _.defaults(options, {
     method: 'GET',
-    gzip: true,
     json: true,
     headers: {},
     refreshToken: true
   });
+  options.gzip = false;
   options.url = url.resolve(settings.get('apiUrl'), options.url);
   return Promise["try"](function() {
     if (!options.refreshToken) {
@@ -161,7 +163,7 @@ exports.stream = function(options) {
   if (options == null) {
     options = {};
   }
-  return prepareOptions(options).then(utils.requestProgress).then(function(download) {
+  return prepareOptions(options).then(progress.estimate).then(function(download) {
     if (!utils.isErrorCode(download.response.statusCode)) {
       download.length = download.response.length;
       download.mime = download.response.headers['content-type'];

--- a/lib/progress.coffee
+++ b/lib/progress.coffee
@@ -1,0 +1,105 @@
+###
+Copyright 2016 Resin.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+###
+
+_ = require('lodash')
+zlib = require('zlib')
+request = require('request')
+stream = require('stream')
+progress = require('progress-stream')
+rindle = require('rindle')
+utils = require('./utils')
+
+###*
+# @summary Get progress stream
+# @function
+# @private
+#
+# @param {Object} response - request response object
+# @param {Number} total - response total
+# @param {Function} [onState] - on state callback (state)
+# @returns {Stream} progress stream
+#
+# @example
+# progressStream = getProgressStream response, (state) ->
+# 	console.log(state)
+#
+# return requestStream.pipe(progressStream).pipe(output)
+###
+getProgressStream = (response, total, onState = _.noop) ->
+	progressStream = progress
+		time: 500
+		length: total
+
+	progressStream.on 'progress', (state) ->
+		if state.length is 0
+			return onState(undefined)
+
+		return onState
+			total: state.length
+			received: state.transferred
+			eta: state.eta
+			percentage: state.percentage
+
+	return progressStream
+
+###*
+# @summary Make a node request with progress
+# @function
+# @protected
+#
+# @param {Object} options - request options
+# @returns {Promise<Stream>} request stream
+#
+# @example
+# progress.estimate(options).then (stream) ->
+#		stream.pipe(fs.createWriteStream('foo/bar'))
+#		stream.on 'progress', (state) ->
+#			console.log(state)
+###
+exports.estimate = (options) ->
+	requestStream = request(options)
+
+	# Instantly pipe the response to a PassThrough stream
+	# to allow data to be piped after `response` was emitted.
+	passStream = new stream.PassThrough()
+	requestStream.pipe(passStream)
+
+	return rindle.onEvent(requestStream, 'response').then (response) ->
+		responseLength = utils.getResponseLength(response)
+
+		output = new stream.PassThrough()
+		output.response = response
+		output.response.length = responseLength.uncompressed
+
+		total = responseLength.uncompressed or responseLength.compressed
+		progressStream = getProgressStream response, total, (state) ->
+			output.emit('progress', state)
+
+		if utils.isResponseCompressed(response)
+			gunzip = new zlib.createGunzip()
+
+			# Uncompress after of before piping trough process
+			# depending on the response length available to us
+			if responseLength.compressed? and not responseLength.uncompressed?
+				passStream.pipe(progressStream).pipe(gunzip).pipe(output)
+			else
+				passStream.pipe(gunzip).pipe(progressStream).pipe(output)
+
+		else
+			passStream.pipe(progressStream).pipe(output)
+
+		return output
+

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -29,15 +29,19 @@ errors = require('resin-errors')
 settings = require('resin-settings-client')
 token = require('resin-token')
 utils = require('./utils')
+progress = require('./progress')
 
 prepareOptions = (options = {}) ->
 
 	_.defaults options,
 		method: 'GET'
-		gzip: true
 		json: true
 		headers: {}
 		refreshToken: true
+
+	# Disable gzip support. We manually handle compression
+	# given the need of finer control.
+	options.gzip = false
 
 	options.url = url.resolve(settings.get('apiUrl'), options.url)
 
@@ -133,7 +137,7 @@ exports.send = (options = {}) ->
 #		stream.pipe(fs.createWriteStream('/opt/download'))
 ###
 exports.stream = (options = {}) ->
-	prepareOptions(options).then(utils.requestProgress).then (download) ->
+	prepareOptions(options).then(progress.estimate).then (download) ->
 		if not utils.isErrorCode(download.response.statusCode)
 
 			# TODO: Move this to resin-image-manager

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "jsdoc-to-markdown": "^1.1.1",
     "mocha": "~2.0.1",
     "mochainon": "^1.0.0",
-    "nock": "^1.2.0",
+    "nock": "^5.3.1",
     "timekeeper": "0.0.5"
   },
   "dependencies": {

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -110,3 +110,86 @@ describe 'Utils:', ->
 
 		it 'should return true for 500', ->
 			m.chai.expect(utils.isErrorCode(500)).to.be.true
+
+	describe '.isResponseCompressed()', ->
+
+		it 'should return false if Content-Encoding is gzip', ->
+			response =
+				headers:
+					'content-encoding': 'gzip'
+
+			m.chai.expect(utils.isResponseCompressed(response)).to.be.true
+
+		it 'should return false if Content-Encoding is not set', ->
+			response =
+				headers: {}
+
+			m.chai.expect(utils.isResponseCompressed(response)).to.be.false
+
+	describe '.getResponseLength()', ->
+
+		describe 'given a response with only an X-Transfer-Length header', ->
+
+			beforeEach ->
+				@response =
+					headers:
+						'x-transfer-length': '1234'
+
+			it 'should return the value of X-Transfer-Length as compressed length', ->
+				m.chai.expect(utils.getResponseLength(@response).compressed).to.equal(1234)
+
+			it 'should set the uncompressed length to undefined', ->
+				m.chai.expect(utils.getResponseLength(@response).uncompressed).to.be.undefined
+
+		describe 'given a response with only a Content-Length header', ->
+
+			beforeEach ->
+				@response =
+					headers:
+						'content-length': '1234'
+
+			it 'should return the value of Content-Length as uncompressed length', ->
+				m.chai.expect(utils.getResponseLength(@response).uncompressed).to.equal(1234)
+
+			it 'should set the compressed length to undefined', ->
+				m.chai.expect(utils.getResponseLength(@response).compressed).to.be.undefined
+
+		describe 'given a response with an empty X-Transfer-Length header', ->
+
+			beforeEach ->
+				@response =
+					headers:
+						'x-transfer-length': ''
+
+			it 'should set the compressed to undefined', ->
+				m.chai.expect(utils.getResponseLength(@response).compressed).to.undefined
+
+		describe 'given a response with an empty Content-Length header', ->
+
+			beforeEach ->
+				@response =
+					headers:
+						'content-length': ''
+
+			it 'should set the uncompressed to undefined', ->
+				m.chai.expect(utils.getResponseLength(@response).uncompressed).to.undefined
+
+		describe 'given a response with an invalid X-Transfer-Length header', ->
+
+			beforeEach ->
+				@response =
+					headers:
+						'x-transfer-length': 'asdf'
+
+			it 'should set the compressed to undefined', ->
+				m.chai.expect(utils.getResponseLength(@response).compressed).to.undefined
+
+		describe 'given a response with an invalid Content-Length header', ->
+
+			beforeEach ->
+				@response =
+					headers:
+						'content-length': 'asdf'
+
+			it 'should set the uncompressed to undefined', ->
+				m.chai.expect(utils.getResponseLength(@response).uncompressed).to.undefined


### PR DESCRIPTION
There was a subtle issue about how we treated compressed requests that
contain a `X-Transfer-Length` header.

This header equals the size of the body in it's *compressed* form. We
were currently treating this value as the total value of the download
and consuming the compressed data stream from `node-request`, resulting
in the download being saved without decompression.

The fix is to check whether `Content-Encoding: gzip` is set to determine
if the content is being received in a compressed form, disabling
automatic `gzip` compression on `node-request` and handling
decompression manually with `zlib`.

By handling decompression ourselves, we can choose to perform this step
after or before checking the stream progress, allowing us to decompress
depending on the total size of the progress being the compressed or
decompressed form.