### PR TITLE
Only disable gzip on stream requests

### DIFF
--- a/build/request.js
+++ b/build/request.js
@@ -50,10 +50,10 @@ prepareOptions = function(options) {
     method: 'GET',
     json: true,
     strictSSL: true,
+    gzip: true,
     headers: {},
     refreshToken: true
   });
-  options.gzip = false;
   options.url = url.resolve(settings.get('apiUrl'), options.url);
   return Promise["try"](function() {
     if (!options.refreshToken) {
@@ -164,7 +164,9 @@ exports.stream = function(options) {
   if (options == null) {
     options = {};
   }
-  return prepareOptions(options).then(progress.estimate).then(function(download) {
+  return prepareOptions(options).tap(function(preparedOptions) {
+    return preparedOptions.gzip = false;
+  }).then(progress.estimate).then(function(download) {
     if (!utils.isErrorCode(download.response.statusCode)) {
       download.length = download.response.length;
       download.mime = download.response.headers['content-type'];

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -37,12 +37,9 @@ prepareOptions = (options = {}) ->
 		method: 'GET'
 		json: true
 		strictSSL: true
+		gzip: true
 		headers: {}
 		refreshToken: true
-
-	# Disable gzip support. We manually handle compression
-	# given the need of finer control.
-	options.gzip = false
 
 	options.url = url.resolve(settings.get('apiUrl'), options.url)
 
@@ -138,7 +135,13 @@ exports.send = (options = {}) ->
 #		stream.pipe(fs.createWriteStream('/opt/download'))
 ###
 exports.stream = (options = {}) ->
-	prepareOptions(options).then(progress.estimate).then (download) ->
+	prepareOptions(options).tap (preparedOptions) ->
+
+		# Disable gzip support. We manually handle compression
+		# given the need of finer control.
+		preparedOptions.gzip = false
+
+	.then(progress.estimate).then (download) ->
 		if not utils.isErrorCode(download.response.statusCode)
 
 			# TODO: Move this to resin-image-manager


### PR DESCRIPTION
Gzip was disabled due to the need of finer control when manipulating
compressed responses from `request.stream`.

This is however not needed for normal requests, where disabling gzip
hurts performance.