### PR TITLE
Enable strictSSL by default

### DIFF
--- a/build/request.js
+++ b/build/request.js
@@ -49,6 +49,7 @@ prepareOptions = function(options) {
   _.defaults(options, {
     method: 'GET',
     json: true,
+    strictSSL: true,
     headers: {},
     refreshToken: true
   });

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -36,6 +36,7 @@ prepareOptions = (options = {}) ->
 	_.defaults options,
 		method: 'GET'
 		json: true
+		strictSSL: true
 		headers: {}
 		refreshToken: true
 


### PR DESCRIPTION
> If true, requires SSL certificates be valid. Note: to use your own
> certificate authority, you need to specify an agent that was created
> with that CA as an option.

https://github.com/request/request#requestoptions-callback