### PR TITLE
Support passing a baseUrl option

### DIFF
--- a/build/request.js
+++ b/build/request.js
@@ -54,7 +54,9 @@ prepareOptions = function(options) {
     headers: {},
     refreshToken: true
   });
-  options.url = url.resolve(settings.get('apiUrl'), options.url);
+  if (options.baseUrl == null) {
+    options.url = url.resolve(settings.get('apiUrl'), options.url);
+  }
   return Promise["try"](function() {
     if (!options.refreshToken) {
       return;

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -41,7 +41,8 @@ prepareOptions = (options = {}) ->
 		headers: {}
 		refreshToken: true
 
-	options.url = url.resolve(settings.get('apiUrl'), options.url)
+	if not options.baseUrl?
+		options.url = url.resolve(settings.get('apiUrl'), options.url)
 
 	Promise.try ->
 		return if not options.refreshToken

--- a/tests/request.spec.coffee
+++ b/tests/request.spec.coffee
@@ -48,6 +48,14 @@ describe 'Request:', ->
 						.get('body')
 						m.chai.expect(promise).to.eventually.become(from: 'foobar')
 
+					it 'should allow passing a baseUrl', ->
+						promise = request.send
+							method: 'GET'
+							baseUrl: 'https://foobar.baz'
+							url: '/foo'
+						.get('body')
+						m.chai.expect(promise).to.eventually.become(from: 'foobar')
+
 				describe 'given there is a token', ->
 
 					beforeEach ->


### PR DESCRIPTION
Newer versions of the Resin SDK will make use of this option to decouple
`resin-request` from SDK settings.