### PR TITLE
Hardcode tokenRefreshInterval setting

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -14,15 +14,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-var Promise, settings, token, _;
+var Promise, token, _;
 
 Promise = require('bluebird');
 
 _ = require('lodash');
 
-settings = require('resin-settings-client');
-
 token = require('resin-token');
+
+exports.TOKEN_REFRESH_INTERVAL = 1 * 1000 * 60 * 60;
 
 
 /**
@@ -44,7 +44,7 @@ token = require('resin-token');
 
 exports.shouldUpdateToken = function() {
   return token.getAge().then(function(age) {
-    return age >= settings.get('tokenRefreshInterval');
+    return age >= exports.TOKEN_REFRESH_INTERVAL;
   });
 };
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -16,8 +16,10 @@ limitations under the License.
 
 Promise = require('bluebird')
 _ = require('lodash')
-settings = require('resin-settings-client')
 token = require('resin-token')
+
+# Expose for testing purposes
+exports.TOKEN_REFRESH_INTERVAL = 1 * 1000 * 60 * 60 # 1 hour in milliseconds
 
 ###*
 # @summary Determine if the token should be updated
@@ -37,7 +39,7 @@ token = require('resin-token')
 ###
 exports.shouldUpdateToken = ->
 	token.getAge().then (age) ->
-		return age >= settings.get('tokenRefreshInterval')
+		return age >= exports.TOKEN_REFRESH_INTERVAL
 
 ###*
 # @summary Get authorization header content

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -2,7 +2,6 @@ ReadableStream = require('stream').Readable
 Promise = require('bluebird')
 m = require('mochainon')
 token = require('resin-token')
-settings = require('resin-settings-client')
 johnDoeFixture = require('./tokens.json').johndoe
 utils = require('../lib/utils')
 
@@ -14,7 +13,7 @@ describe 'Utils:', ->
 
 			beforeEach ->
 				@tokenGetAgeStub = m.sinon.stub(token, 'getAge')
-				@tokenGetAgeStub.returns(Promise.resolve(settings.get('tokenRefreshInterval') + 1))
+				@tokenGetAgeStub.returns(Promise.resolve(utils.TOKEN_REFRESH_INTERVAL + 1))
 
 			afterEach ->
 				@tokenGetAgeStub.restore()
@@ -26,7 +25,7 @@ describe 'Utils:', ->
 
 			beforeEach ->
 				@tokenGetAgeStub = m.sinon.stub(token, 'getAge')
-				@tokenGetAgeStub.returns(Promise.resolve(settings.get('tokenRefreshInterval') - 1))
+				@tokenGetAgeStub.returns(Promise.resolve(utils.TOKEN_REFRESH_INTERVAL - 1))
 
 			afterEach ->
 				@tokenGetAgeStub.restore()
@@ -38,7 +37,7 @@ describe 'Utils:', ->
 
 			beforeEach ->
 				@tokenGetAgeStub = m.sinon.stub(token, 'getAge')
-				@tokenGetAgeStub.returns(Promise.resolve(settings.get('tokenRefreshInterval')))
+				@tokenGetAgeStub.returns(Promise.resolve(utils.TOKEN_REFRESH_INTERVAL))
 
 			afterEach ->
 				@tokenGetAgeStub.restore()


### PR DESCRIPTION
This setting is too low level for users to have any reason for customise
it, and the value hugely depends on the expiry time set by the Resin
API, therefore having it under our control prevents broken applications
by Resin modifying the expiry time and a user keeping an old
configuration.