### PR TITLE
Set a default timeout of 30s

### DIFF
--- a/build/request.js
+++ b/build/request.js
@@ -52,7 +52,8 @@ prepareOptions = function(options) {
     strictSSL: true,
     gzip: true,
     headers: {},
-    refreshToken: true
+    refreshToken: true,
+    timeout: 30000
   });
   if (options.baseUrl == null) {
     options.url = url.resolve(settings.get('apiUrl'), options.url);

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -40,6 +40,7 @@ prepareOptions = (options = {}) ->
 		gzip: true
 		headers: {}
 		refreshToken: true
+		timeout: 30000
 
 	if not options.baseUrl?
 		options.url = url.resolve(settings.get('apiUrl'), options.url)


### PR DESCRIPTION
This default option previously lived in `resin-pine`, but its nicer to
move it here so `resin-pine` and any other clients get it automatically.