### PR TITLE
Throw an informative error when the token is expired

### DIFF
--- a/build/request.js
+++ b/build/request.js
@@ -68,6 +68,13 @@ prepareOptions = function(options) {
       return exports.send({
         url: '/whoami',
         refreshToken: false
+      })["catch"](function(error) {
+        if (error instanceof errors.ResinRequestError && error.statusCode === 401) {
+          return token.get().then(function(sessionToken) {
+            throw new errors.ResinExpiredToken(sessionToken);
+          });
+        }
+        throw error;
       }).get('body').then(token.set);
     });
   }).then(utils.getAuthorizationHeader).then(function(authorizationHeader) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^3.5.0",
     "progress-stream": "^1.1.1",
     "request": "^2.53.0",
-    "resin-errors": "^2.2.0",
+    "resin-errors": "^2.3.0",
     "resin-settings-client": "^3.0.0",
     "resin-token": "^2.4.1",
     "rindle": "^1.2.0"


### PR DESCRIPTION
If there is a saved token that needs to be refreshed, but it already
expired, the client will get a 'Not Authorized' error.

We can catch this corner case by inspecting the response of the
`GET /whoami` request, which is issued to refresh the token. If the
resulting status code is `401`, we know it represents an scenario where
the token is expired.

Fixes: https://github.com/resin-io/resin-cli/issues/318